### PR TITLE
Accessibility and bug fixes of issues 15-17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # ilw-back-to-top
 ## Overview
-This component places a button in the bottom-right corner of the screen which takes visitors back to the top of the page. It uses animation that simulates vertical scrolling while not being overwhelming for motion-sensitive viewers.
+This component places a button in the bottom-right corner of the screen which takes visitors back to the top of the page.
 
-This component should be placed as close as possible to the ending `</body>` tag, outside of any `<ilw-page>` element in use.
+## Placement Guidance
+
+The preferred placement is as close as possible to the ending `</body>` tag, outside of any `<ilw-page>` element in use, so the button behaves like a page-level utility control. You can also place the component inside the `<footer>` tag.
 
 By default, this component will take the visitor to the top edge of the page. To change the location of the top of the page, use the `target` attribute.
+
+## Accessibility
+
+This component respects the user's reduced-motion preference. If the user has enabled Reduced Motion on their device, clicking the button scrolls directly to the top target instead of using the stepped scroll effect.
 
 ## Code Examples
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Illinois Toolkit: The Illinois component back-to-top allows you to provide a simple way to skip either to the top of a page or to a designated point in the page (such as the page content area).",
   "private": false,
   "license": "MIT",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "type": "module",
   "files": [
     "src/**",

--- a/src/ilw-back-to-top.ts
+++ b/src/ilw-back-to-top.ts
@@ -101,6 +101,11 @@ export default class BackToTop extends LitElement {
     return window.scrollY || document.documentElement.scrollTop;
   }
 
+  private prefersReducedMotion(): boolean {
+    return typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+
   // Helper method to find the first focusable element on the page
   private getFirstFocusableElement(): Element | null {
     const focusableSelectors = [
@@ -149,7 +154,11 @@ export default class BackToTop extends LitElement {
     if (button) {
       button.blur();
     }
-    if (this.isBelowFold()) this.jumpToFold();
+
+    if (!this.prefersReducedMotion() && this.isBelowFold()) {
+      this.jumpToFold();
+    }
+
     this.startScrollToTop();
   }
 
@@ -177,7 +186,18 @@ export default class BackToTop extends LitElement {
     setTimeout(this.continueScroll, 10);
   }
 
+  private scrollToTopImmediately(): void {
+    this.expectedPositionAfterScroll = null;
+    window.scrollTo(0, this.topOfPage);
+    this.focusFirstElement();
+  }
+
   private startScrollToTop(): void {
+    if (this.prefersReducedMotion()) {
+      this.scrollToTopImmediately();
+      return;
+    }
+
     this.scrollToTop();
   }
 

--- a/src/ilw-back-to-top.ts
+++ b/src/ilw-back-to-top.ts
@@ -103,11 +103,11 @@ export default class BackToTop extends LitElement {
 
   private prefersReducedMotion(): boolean {
     return typeof window.matchMedia === 'function' &&
-      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 
-  // Helper method to find the first focusable element on the page
-  private getFirstFocusableElement(): Element | null {
+  // Helper method to find the first focusable element within a given root element
+  private getFirstFocusableElement(root: Document | Element = document): Element | null {
     const focusableSelectors = [
       'a[href]',
       'button:not([disabled])',
@@ -121,7 +121,7 @@ export default class BackToTop extends LitElement {
       'details > summary'
     ];
 
-    const focusableElements = document.querySelectorAll(focusableSelectors.join(','));
+    const focusableElements = root.querySelectorAll(focusableSelectors.join(','));
 
     // Filter out elements that are not visible or have negative tabindex
     for (let element of focusableElements) {
@@ -139,9 +139,29 @@ export default class BackToTop extends LitElement {
     return null;
   }
 
-  // Method to focus the first focusable element
+  // Method to focus the first focusable element, scoped to the target element if set
   private focusFirstElement(): void {
-    const firstFocusable = this.getFirstFocusableElement() as HTMLElement | null;
+    let firstFocusable: HTMLElement | null = null;
+
+    if (this.target) {
+      const targetElement = document.getElementById(this.target);
+      if (targetElement) {
+        // Focus the target itself if focusable, otherwise its first focusable child
+        const isFocusable = targetElement.tabIndex >= 0 ||
+          targetElement.hasAttribute('href') ||
+          targetElement.hasAttribute('controls');
+        if (isFocusable) {
+          firstFocusable = targetElement;
+        } else {
+          firstFocusable = this.getFirstFocusableElement(targetElement) as HTMLElement | null;
+        }
+      }
+    }
+
+    if (!firstFocusable) {
+      firstFocusable = this.getFirstFocusableElement() as HTMLElement | null;
+    }
+
     if (firstFocusable) {
       firstFocusable.focus();
     }
@@ -172,8 +192,11 @@ export default class BackToTop extends LitElement {
   }
 
   private isInExpectedPosition(): boolean {
-    return this.expectedPositionAfterScroll !== null &&
-        this.getScrollPosition() === this.expectedPositionAfterScroll;
+    if (this.expectedPositionAfterScroll === null) return false;
+    // Use a 60px tolerance to account for mobile browsers shifting scrollY when the
+    // address bar shows/hides (~50px on iOS). We stop only if the user has scrolled
+    // clearly downward past the expected position.
+    return this.getScrollPosition() <= this.expectedPositionAfterScroll + 60;
   }
 
   private jumpToFold(): void {
@@ -183,7 +206,7 @@ export default class BackToTop extends LitElement {
   private scrollToTop(): void {
     this.expectedPositionAfterScroll = this.getNextScrollPosition();
     window.scrollTo(0, this.expectedPositionAfterScroll);
-    setTimeout(this.continueScroll, 10);
+    requestAnimationFrame(this.continueScroll);
   }
 
   private scrollToTopImmediately(): void {


### PR DESCRIPTION
Fixes #15 
Fixes #16 
Fixes #17 

Moves to top without scrolling if a user has set this reduced motion prefernce of their device. 
Update README with alternative placement in footer of back to top component.
Fixes scroll to top on mobile on iOS.